### PR TITLE
MES-1067 - Implement Retry Logic for PLC Connection Loss in Gateway

### DIFF
--- a/app/service/PLC/plc_client.py
+++ b/app/service/PLC/plc_client.py
@@ -1,10 +1,8 @@
-import time
-
 import snap7
-from service.PLC.plc_types import TYPE_SPECS
-from service.PLC.plc_utils import require_connection
 from snap7 import types, util
 from snap7.exceptions import Snap7Exception
+from service.PLC.plc_utils import require_connection
+from service.PLC.plc_types import TYPE_SPECS
 from utility.logger import Logger
 
 logger = Logger.get_logger(__name__)
@@ -18,18 +16,11 @@ class PLCClient:
         self.plc = snap7.client.Client()
 
     def connect(self):
-        while True:
-            try:
-                self.plc.connect(self.ip, self.rack, self.slot)
-                logger.info("Connected to PLC at %s", self.ip)
-                break
-            except (Snap7Exception, RuntimeError) as e:
-                logger.error(
-                    "Error connecting to PLC %s: %s. Retrying in 5 seconds...",
-                    self.ip,
-                    e,
-                )
-                time.sleep(5)
+        try:
+            self.plc.connect(self.ip, self.rack, self.slot)
+            logger.info("Connected to PLC at %s", self.ip)
+        except Snap7Exception as e:
+            logger.error("Error connecting to PLC: %s", e)
 
     def disconnect(self):
         try:

--- a/app/service/plc_connection_manager.py
+++ b/app/service/plc_connection_manager.py
@@ -1,3 +1,4 @@
+import threading
 import time
 
 from service.PLC.plc_client import PLCClient
@@ -11,24 +12,29 @@ class PlcConnectionManager:
     def __init__(self, plc_client_factory=PLCClient):
         self.plc_client_factory = plc_client_factory
         self.plc_clients = {}
+        self.lock = threading.Lock()
 
     def get_plc_client(self, ip: str) -> PLCClient:
-        if ip not in self.plc_clients:
+        with self.lock:
+            if ip in self.plc_clients:
+                return self.plc_clients[ip]
+
+        client = self.plc_client_factory(ip)
+
+        def try_connect_forever():
             while True:
                 try:
-                    client = self.plc_client_factory(ip)
                     client.connect()
-                    self.plc_clients[ip] = client
+                    with self.lock:
+                        self.plc_clients[ip] = client
                     logger.info("PLC client connected successfully to %s.", ip)
                     break
-                except Snap7Exception as e:
-                    logger.error(
-                        "Failed to connect to PLC %s: %s. Retrying in 5 seconds...",
-                        ip,
-                        e,
-                    )
-                    time.sleep(5)
-        return self.plc_clients[ip]
+                except (Snap7Exception, RuntimeError) as e:
+                    logger.warning("Retrying connection to PLC %s: %s", ip, e)
+                    time.sleep(60)
+
+        threading.Thread(target=try_connect_forever, daemon=True).start()
+        return client
 
     def disconnect_all(self):
         for ip, client in self.plc_clients.items():

--- a/app/service/plc_service.py
+++ b/app/service/plc_service.py
@@ -26,8 +26,15 @@ class PlcService:
         for equipment in equipments:
             if equipment.ip:
                 logger.info("Attempting to connect to PLC at %s...", equipment.ip)
-                self.plc_connection_manager.get_plc_client(equipment.ip)
-                logger.info("Connected to PLC %s on startup.", equipment.ip)
+                try:
+                    self.plc_connection_manager.get_plc_client(equipment.ip)
+                    logger.info("Connected to PLC %s on startup.", equipment.ip)
+                except Exception as e:
+                    logger.error(
+                        "Failed to connect to PLC %s. Will retry in background. Error: %s",
+                        equipment.ip,
+                        e,
+                    )
 
     def read_plc_data(self, equipment_id, equipment_ip):
         plc = self.plc_connection_manager.get_plc_client(equipment_ip)


### PR DESCRIPTION
## Summary by Sourcery

Implement retry logic for PLC connection loss in the gateway. This change ensures that the gateway attempts to reconnect to PLCs if the connection is lost, improving the reliability of the system.